### PR TITLE
Conform to project style

### DIFF
--- a/src/main/java/frc/team1816/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/team1816/robot/subsystems/Drivetrain.java
@@ -10,34 +10,40 @@ public class Drivetrain extends Subsystem {
 
     private PigeonIMU gyro;
 
-    private TalonSRX rightMain, rightSlaveOne, rightSlaveTwo;
-    private TalonSRX leftMain, leftSlaveOne, leftSlaveTwo;
+    private TalonSRX rightMain;
+    private TalonSRX rightSlaveOne;
+    private TalonSRX rightSlaveTwo;
 
-    private double leftPower, rightPower;
+    private TalonSRX leftMain;
+    private TalonSRX leftSlaveOne;
+    private TalonSRX leftSlaveTwo;
+
+    private double leftPower;
+    private double rightPower;
 
     private boolean isPercentOut;
 
     public Drivetrain(
-            int pigeonID,
-            int leftMainID, int leftSlaveOneID, int leftSlaveTwoID,
-            int rightMainID, int rightSlaveOneID, int rightSlaveTwoID
+            int pigeonId,
+            int leftMainId, int leftSlaveOneId, int leftSlaveTwoId,
+            int rightMainId, int rightSlaveOneId, int rightSlaveTwoId
     ) {
         super("Drivetrain");
 
-        this.gyro = new PigeonIMU(pigeonID);
+        this.gyro = new PigeonIMU(pigeonId);
 
-        this.leftMain = new TalonSRX(leftMainID);
-        this.leftSlaveOne = new TalonSRX(leftSlaveOneID);
-        this.leftSlaveTwo = new TalonSRX(leftSlaveTwoID);
+        this.leftMain = new TalonSRX(leftMainId);
+        this.leftSlaveOne = new TalonSRX(leftSlaveOneId);
+        this.leftSlaveTwo = new TalonSRX(leftSlaveTwoId);
 
-        this.rightMain = new TalonSRX(rightMainID);
-        this.rightSlaveOne = new TalonSRX(rightSlaveOneID);
-        this.rightSlaveTwo = new TalonSRX(rightSlaveTwoID);
+        this.rightMain = new TalonSRX(rightMainId);
+        this.rightSlaveOne = new TalonSRX(rightSlaveOneId);
+        this.rightSlaveTwo = new TalonSRX(rightSlaveTwoId);
 
-        this.leftSlaveOne.set(ControlMode.Follower, leftMainID);
-        this.leftSlaveTwo.set(ControlMode.Follower, leftMainID);
-        this.rightSlaveOne.set(ControlMode.Follower, rightMainID);
-        this.rightSlaveTwo.set(ControlMode.Follower, rightMainID);
+        this.leftSlaveOne.set(ControlMode.Follower, leftMainId);
+        this.leftSlaveTwo.set(ControlMode.Follower, leftMainId);
+        this.rightSlaveOne.set(ControlMode.Follower, rightMainId);
+        this.rightSlaveTwo.set(ControlMode.Follower, rightMainId);
 
         this.leftMain.setInverted(true);
         this.leftSlaveOne.setInverted(true);


### PR DESCRIPTION
The Checkstyle configuration we are using is based on the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).

The Google Java Style Guide recommends against [declaring multiple variables in one declaration](https://google.github.io/styleguide/javaguide.html), instead using blank lines to create logical groupings of variables like so:

```java
private TalonSRX leftMain;
private TalonSRX leftSlaveOne;

private TalonSRX rightMain;
private TalonSRX rightSlaveOne;
```

This is so that the signature of individual fields can be changed easily without much refactoring.

The Google Java Style Guide also recommends following consistent CamelCase by lowercasing all letters that aren't the first of a word, e.g `"iOS YouTube Importer"` becomes `IosYouTubeImporter`. This is the standard followed by the wider Java community, even those not using the Google Java Style Guide.

This pull request, if merged, will rename `pigeonID` etc. to `pigeonId`. 

This is entirely up for debate and we can modify our style to allow for either multiple variable declaration or capital abbreviations in class names, but in my personal opinion we should attempt to follow the Style Guide closely as possible.