### PR TITLE
Added CheezyDryamlive to zeta

### DIFF
--- a/src/main/java/com/team254/lib/util/CheesyDriveHelper.java
+++ b/src/main/java/com/team254/lib/util/CheesyDriveHelper.java
@@ -1,0 +1,143 @@
+package com.team254.lib.util;
+
+/**
+ * Helper class to implement "Cheesy Drive". "Cheesy Drive" simply means that the "turning" stick controls the curvature
+ * of the robot's path rather than its rate of heading change. This helps make the robot more controllable at high
+ * speeds. Also handles the robot's quick turn functionality - "quick turn" overrides constant-curvature turning for
+ * turn-in-place maneuvers.
+ */
+public class CheesyDriveHelper {
+
+    private static final double kThrottleDeadband = 0.02;
+    private static final double kWheelDeadband = 0.02;
+
+    // These factor determine how fast the wheel traverses the "non linear" sine curve.
+    private static final double kHighWheelNonLinearity = 0.65;
+    private static final double kLowWheelNonLinearity = 0.5;
+
+    private static final double kHighNegInertiaScalar = 4.0;
+
+    private static final double kLowNegInertiaThreshold = 0.65;
+    private static final double kLowNegInertiaTurnScalar = 3.5;
+    private static final double kLowNegInertiaCloseScalar = 4.0;
+    private static final double kLowNegInertiaFarScalar = 5.0;
+
+    private static final double kHighSensitivity = 0.65;
+    private static final double kLowSensitiity = 0.65;
+
+    private static final double kQuickStopDeadband = 0.5;
+    private static final double kQuickStopWeight = 0.1;
+    private static final double kQuickStopScalar = 5.0;
+
+    private double mOldWheel = 0.0;
+    private double mQuickStopAccumlator = 0.0;
+    private double mNegInertiaAccumlator = 0.0;
+
+    public DriveSignal cheesyDrive(double throttle, double wheel, boolean isQuickTurn,
+                                   boolean isHighGear) {
+
+        wheel = handleDeadband(wheel, kWheelDeadband);
+        throttle = handleDeadband(throttle, kThrottleDeadband);
+
+        double negInertia = wheel - mOldWheel;
+        mOldWheel = wheel;
+
+        double wheelNonLinearity;
+        if (isHighGear) {
+            wheelNonLinearity = kHighWheelNonLinearity;
+            final double denominator = Math.sin(Math.PI / 2.0 * wheelNonLinearity);
+            // Apply a sin function that's scaled to make it feel better.
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+        } else {
+            wheelNonLinearity = kLowWheelNonLinearity;
+            final double denominator = Math.sin(Math.PI / 2.0 * wheelNonLinearity);
+            // Apply a sin function that's scaled to make it feel better.
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+            wheel = Math.sin(Math.PI / 2.0 * wheelNonLinearity * wheel) / denominator;
+        }
+
+        double leftPwm, rightPwm, overPower;
+        double sensitivity;
+
+        double angularPower;
+        double linearPower;
+
+        // Negative inertia!
+        double negInertiaScalar;
+        if (isHighGear) {
+            negInertiaScalar = kHighNegInertiaScalar;
+            sensitivity = kHighSensitivity;
+        } else {
+            if (wheel * negInertia > 0) {
+                // If we are moving away from 0.0, aka, trying to get more wheel.
+                negInertiaScalar = kLowNegInertiaTurnScalar;
+            } else {
+                // Otherwise, we are attempting to go back to 0.0.
+                if (Math.abs(wheel) > kLowNegInertiaThreshold) {
+                    negInertiaScalar = kLowNegInertiaFarScalar;
+                } else {
+                    negInertiaScalar = kLowNegInertiaCloseScalar;
+                }
+            }
+            sensitivity = kLowSensitiity;
+        }
+        double negInertiaPower = negInertia * negInertiaScalar;
+        mNegInertiaAccumlator += negInertiaPower;
+
+        wheel = wheel + mNegInertiaAccumlator;
+        if (mNegInertiaAccumlator > 1) {
+            mNegInertiaAccumlator -= 1;
+        } else if (mNegInertiaAccumlator < -1) {
+            mNegInertiaAccumlator += 1;
+        } else {
+            mNegInertiaAccumlator = 0;
+        }
+        linearPower = throttle;
+
+        // Quickturn!
+        if (isQuickTurn) {
+            if (Math.abs(linearPower) < kQuickStopDeadband) {
+                double alpha = kQuickStopWeight;
+                mQuickStopAccumlator = (1 - alpha) * mQuickStopAccumlator
+                        + alpha * Util.limit(wheel, 1.0) * kQuickStopScalar;
+            }
+            overPower = 1.0;
+            angularPower = wheel;
+        } else {
+            overPower = 0.0;
+            angularPower = Math.abs(throttle) * wheel * sensitivity - mQuickStopAccumlator;
+            if (mQuickStopAccumlator > 1) {
+                mQuickStopAccumlator -= 1;
+            } else if (mQuickStopAccumlator < -1) {
+                mQuickStopAccumlator += 1;
+            } else {
+                mQuickStopAccumlator = 0.0;
+            }
+        }
+
+        rightPwm = leftPwm = linearPower;
+        leftPwm += angularPower;
+        rightPwm -= angularPower;
+
+        if (leftPwm > 1.0) {
+            rightPwm -= overPower * (leftPwm - 1.0);
+            leftPwm = 1.0;
+        } else if (rightPwm > 1.0) {
+            leftPwm -= overPower * (rightPwm - 1.0);
+            rightPwm = 1.0;
+        } else if (leftPwm < -1.0) {
+            rightPwm += overPower * (-1.0 - leftPwm);
+            leftPwm = -1.0;
+        } else if (rightPwm < -1.0) {
+            leftPwm += overPower * (-1.0 - rightPwm);
+            rightPwm = -1.0;
+        }
+        return new DriveSignal(leftPwm, rightPwm);
+    }
+
+    public double handleDeadband(double val, double deadband) {
+        return (Math.abs(val) > Math.abs(deadband)) ? val : 0.0;
+    }
+}

--- a/src/main/java/com/team254/lib/util/DriveSignal.java
+++ b/src/main/java/com/team254/lib/util/DriveSignal.java
@@ -1,0 +1,40 @@
+package com.team254.lib.util;
+
+/**
+ * A drivetrain command consisting of the left, right motor settings and whether the brake mode is enabled.
+ */
+public class DriveSignal {
+    protected double mLeftMotor;
+    protected double mRightMotor;
+    protected boolean mBrakeMode;
+
+    public DriveSignal(double left, double right) {
+        this(left, right, false);
+    }
+
+    public DriveSignal(double left, double right, boolean brakeMode) {
+        mLeftMotor = left;
+        mRightMotor = right;
+        mBrakeMode = brakeMode;
+    }
+
+    public static DriveSignal NEUTRAL = new DriveSignal(0, 0);
+    public static DriveSignal BRAKE = new DriveSignal(0, 0, true);
+
+    public double getLeft() {
+        return mLeftMotor;
+    }
+
+    public double getRight() {
+        return mRightMotor;
+    }
+
+    public boolean getBrakeMode() {
+        return mBrakeMode;
+    }
+
+    @Override
+    public String toString() {
+        return "L: " + mLeftMotor + ", R: " + mRightMotor + (mBrakeMode ? ", BRAKE" : "");
+    }
+}

--- a/src/main/java/com/team254/lib/util/Util.java
+++ b/src/main/java/com/team254/lib/util/Util.java
@@ -1,0 +1,64 @@
+package com.team254.lib.util;
+
+import java.util.List;
+
+/**
+ * Contains basic functions that are used often.
+ */
+public class Util {
+
+    public static final double kEpsilon = 1e-12;
+
+    /**
+     * Prevent this class from being instantiated.
+     */
+    private Util() {
+    }
+
+    /**
+     * Limits the given input to the given magnitude.
+     */
+    public static double limit(double v, double maxMagnitude) {
+        return limit(v, -maxMagnitude, maxMagnitude);
+    }
+
+    public static double limit(double v, double min, double max) {
+        return Math.min(max, Math.max(min, v));
+    }
+
+    public static double interpolate(double a, double b, double x) {
+        x = limit(x, 0.0, 1.0);
+        return a + (b - a) * x;
+    }
+
+    public static String joinStrings(final String delim, final List<?> strings) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < strings.size(); ++i) {
+            sb.append(strings.get(i).toString());
+            if (i < strings.size() - 1) {
+                sb.append(delim);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static boolean epsilonEquals(double a, double b, double epsilon) {
+        return (a - epsilon <= b) && (a + epsilon >= b);
+    }
+
+    public static boolean epsilonEquals(double a, double b) {
+        return epsilonEquals(a, b, kEpsilon);
+    }
+
+    public static boolean epsilonEquals(int a, int b, int epsilon) {
+        return (a - epsilon <= b) && (a + epsilon >= b);
+    }
+
+    public static boolean allCloseTo(final List<Double> list, double value, double epsilon) {
+        boolean result = true;
+        for (Double value_in : list) {
+            result &= epsilonEquals(value_in, value, epsilon);
+        }
+        return result;
+    }
+}

--- a/src/main/java/frc/team1816/robot/Controls.java
+++ b/src/main/java/frc/team1816/robot/Controls.java
@@ -104,6 +104,10 @@ public class Controls {
         return gamepadDriver.getRightX();
     }
 
+    public boolean getQuickTurn() {
+        return gamepadDriver.diamondUp().get();
+    }
+
     public double getClimbThrottle() {
         return gamepadOperator.getLeftY();
     }

--- a/src/main/java/frc/team1816/robot/Controls.java
+++ b/src/main/java/frc/team1816/robot/Controls.java
@@ -105,7 +105,7 @@ public class Controls {
     }
 
     public boolean getQuickTurn() {
-        return gamepadDriver.diamondUp().get();
+        return gamepadDriver.diamondDown().get();
     }
 
     public double getClimbThrottle() {

--- a/src/main/java/frc/team1816/robot/commands/GamepadDriveCommand.java
+++ b/src/main/java/frc/team1816/robot/commands/GamepadDriveCommand.java
@@ -34,7 +34,7 @@ public class GamepadDriveCommand extends Command {
         double rightPow = leftPow;
         double rotation = Controls.getInstance().getDriveTurn();
 
-        if (factory.getConstant("cheezyDrive") == 0) {
+        if (factory.getConstant("cheezyDrive") == 0) { // Arcade Drive
             if (rotation == 0 || leftPow != 0) {
                 leftPow = limitAcceleration(leftPow, prevPowLeft);
                 rightPow = limitAcceleration(rightPow, prevPowRight);
@@ -42,7 +42,7 @@ public class GamepadDriveCommand extends Command {
 
             prevPowLeft = leftPow;
             prevPowRight = rightPow;
-        } else {
+        } else { //  Cheesy Drive
             boolean quickTurn = Controls.getInstance().getQuickTurn();
             var signal = mCheesyDriveHelper.cheesyDrive(leftPow, rotation, quickTurn, false);
             leftPow = signal.getLeft();

--- a/src/main/java/frc/team1816/robot/commands/GamepadDriveCommand.java
+++ b/src/main/java/frc/team1816/robot/commands/GamepadDriveCommand.java
@@ -1,14 +1,17 @@
 package frc.team1816.robot.commands;
 
+import com.team254.lib.util.CheesyDriveHelper;
 import edu.wpi.first.wpilibj.command.Command;
 import frc.team1816.robot.Controls;
 import frc.team1816.robot.Components;
 import frc.team1816.robot.subsystems.Drivetrain;
+import static frc.team1816.robot.Robot.factory;
 
 public class GamepadDriveCommand extends Command {
     private static final String NAME = "gamepaddrivecommand";
 
     private Drivetrain drivetrain;
+    CheesyDriveHelper mCheesyDriveHelper = new CheesyDriveHelper();
 
     private double prevPowLeft = 0;
     private double prevPowRight = 0;
@@ -28,16 +31,24 @@ public class GamepadDriveCommand extends Command {
     @Override
     protected void execute() {
         double leftPow = Controls.getInstance().getDriveThrottle();
-        double rightPow = Controls.getInstance().getDriveThrottle();
+        double rightPow = leftPow;
         double rotation = Controls.getInstance().getDriveTurn();
 
-        if(rotation == 0 || leftPow != 0) {
-            leftPow = limitAcceleration(leftPow, prevPowLeft);
-            rightPow = limitAcceleration(rightPow, prevPowRight);
-        }
+        if (factory.getConstant("cheezyDrive") == 0) {
+            if (rotation == 0 || leftPow != 0) {
+                leftPow = limitAcceleration(leftPow, prevPowLeft);
+                rightPow = limitAcceleration(rightPow, prevPowRight);
+            }
 
-        prevPowLeft = leftPow;
-        prevPowRight = rightPow;
+            prevPowLeft = leftPow;
+            prevPowRight = rightPow;
+        }else {
+            // TODO map quick turn to button?
+            var signal = mCheesyDriveHelper.cheesyDrive(leftPow, rotation, false, false);
+            leftPow = signal.getLeft();
+            rightPow = signal.getRight();
+            rotation = 0;  // CheezyDrive takes care of rotation so set to 0 to keep or code from adjusting
+        }
 
         drivetrain.setDrivetrainPercent(leftPow, rightPow, rotation);
     }

--- a/src/main/java/frc/team1816/robot/commands/GamepadDriveCommand.java
+++ b/src/main/java/frc/team1816/robot/commands/GamepadDriveCommand.java
@@ -42,9 +42,9 @@ public class GamepadDriveCommand extends Command {
 
             prevPowLeft = leftPow;
             prevPowRight = rightPow;
-        }else {
-            // TODO map quick turn to button?
-            var signal = mCheesyDriveHelper.cheesyDrive(leftPow, rotation, false, false);
+        } else {
+            boolean quickTurn = Controls.getInstance().getQuickTurn();
+            var signal = mCheesyDriveHelper.cheesyDrive(leftPow, rotation, quickTurn, false);
             leftPow = signal.getLeft();
             rightPow = signal.getRight();
             rotation = 0;  // CheezyDrive takes care of rotation so set to 0 to keep or code from adjusting

--- a/src/main/resources/CheezeCurd.config.yml
+++ b/src/main/resources/CheezeCurd.config.yml
@@ -6,6 +6,7 @@ subsystems:
       leftSlaveOne: -1
       rightMain: 2
       rightSlaveOne: -1
+    victors:
       rightSlaveTwo: -1
       leftSlaveTwo: -1
   climber:
@@ -37,16 +38,17 @@ subsystems:
       arm: 5
       intake: 10
     constants:
-      kP: 2.0
-      kI: .001
-      kD: 10.0
-      kF: 1.85
-      maxPos: 1475
-      midPos: 1195
-      minPos: 915
-pcm: 17
+      kP: 5.0
+      kI: 0
+      kD: 1.0
+      kF: 0
+      maxPos: 2100
+      midPos: 2100
+      minPos: 950
+pcm: -1
 constants:
-  wheelbase: 25
-  ticksPerRev: 1025
-  ticksPerIn: 50
+  wheelbase: 15.75
+  ticksPerRev: 960
+  ticksPerIn: 78
   maxVel: 800
+  cheezyDrive: 1

--- a/src/main/resources/zeta_practice.config.yml
+++ b/src/main/resources/zeta_practice.config.yml
@@ -51,3 +51,4 @@ constants:
   ticksPerRev: 1025
   ticksPerIn: 50
   maxVel: 800
+  cheezyDrive: 1

--- a/src/main/resources/zeta_practice.config.yml
+++ b/src/main/resources/zeta_practice.config.yml
@@ -51,4 +51,4 @@ constants:
   ticksPerRev: 1025
   ticksPerIn: 50
   maxVel: 800
-  cheezyDrive: 1
+  cheezyDrive: 0


### PR DESCRIPTION
CheezyDrive can be enabled or disabled via yaml

I also organized gamepad commands by subsystem so they can be disable via yaml.

@andrewfhou 
Mittag and Cole wanted to try this.  So I hooked it into our code with minimal changes.  I tested on CheezeCurd hence the extra rearranging of the commands.  I would like to try this on Sunday and we can get Coles feedback.  We may need a button for quick turn and high speed.