### PR TITLE
RobotFactory cleanup, move YamlConfig to separate file

### DIFF
--- a/src/main/java/com/edinarobotics/utils/hardware/RobotFactory.java
+++ b/src/main/java/com/edinarobotics/utils/hardware/RobotFactory.java
@@ -4,22 +4,14 @@ import com.ctre.phoenix.CANifier;
 import com.ctre.phoenix.motorcontrol.IMotorController;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.Solenoid;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-import org.yaml.snakeyaml.introspector.BeanAccess;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class RobotFactory {
 
-    private YamlConfiguration config;
+    private YamlConfig config;
 
     public RobotFactory(String configName) {
-        System.out.println("Loading Config for "+ configName);
-        Yaml yaml = new Yaml(new Constructor(YamlConfiguration.class));
-        yaml.setBeanAccess(BeanAccess.FIELD);
-        config = yaml.load(
+        System.out.println("Loading Config for " + configName);
+        config = YamlConfig.loadFrom(
             this.getClass()
                 .getClassLoader()
                 .getResourceAsStream(configName + ".config.yml")
@@ -30,60 +22,55 @@ public class RobotFactory {
         return (getSubsystem(subsystem) != null) && (getSubsystem(subsystem).implemented);
     }
 
-    public IMotorController getMotor(String subsystem, String name) {
-        if (!isImplemented(subsystem)) return CtreMotorFactory.createGhostTalon();
-        YamlConfiguration.SubsystemConfig subsystemConfig = getSubsystem(subsystem);
-        if (
-            subsystemConfig.talons.get(name) != null &&
-            subsystemConfig.talons.get(name) > -1
-        ) {
-            return CtreMotorFactory.createDefaultTalon(subsystemConfig.talons.get(name));
-        } else if (
-            subsystemConfig.victors.get(name) != null &&
-            subsystemConfig.victors.get(name) > -1
-        ) {
-            return CtreMotorFactory.createDefaultVictor(subsystemConfig.victors.get(name));
+    public IMotorController getMotor(String subsystemName, String name) {
+        if (isImplemented(subsystemName)) {
+            YamlConfig.SubsystemConfig subsystem = getSubsystem(subsystemName);
+            if (isHardwareValid(subsystem.talons.get(name))) {
+                return CtreMotorFactory.createDefaultTalon(subsystem.talons.get(name));
+            } else if (isHardwareValid(subsystem.victors.get(name))) {
+                return CtreMotorFactory.createDefaultVictor(subsystem.victors.get(name));
+            }
         }
         return CtreMotorFactory.createGhostTalon();
     }
 
-    public IMotorController getMotor(String subsystem, String name, IMotorController master) {
-        if (!isImplemented(subsystem)) return CtreMotorFactory.createGhostTalon();
-        YamlConfiguration.SubsystemConfig subsystemConfig = getSubsystem(subsystem);
-        if (
-            subsystemConfig.talons.get(name) != null &&
-            subsystemConfig.talons.get(name) > -1 &&
-            master != null
-        ) {
-            // Talons must be following another Talon, cannot follow a Victor.
-            return CtreMotorFactory.createPermanentSlaveTalon(
-                    subsystemConfig.talons.get(name), master
-            );
-        } else if (
-            subsystemConfig.victors.get(name) != null &&
-            subsystemConfig.victors.get(name) > -1
-        ) {
-            // Victors can follow Talons or another Victor.
-            if (master != null) {
+    public IMotorController getMotor(String subsystemName, String name, IMotorController master) {
+        if (isImplemented(subsystemName) && master != null) {
+            YamlConfig.SubsystemConfig subsystem = getSubsystem(subsystemName);
+            if (isHardwareValid(subsystem.talons.get(name))) {
+                // Talons must be following another Talon, cannot follow a Victor.
+                return CtreMotorFactory.createPermanentSlaveTalon(
+                    subsystem.talons.get(name), master
+                );
+            } else if (isHardwareValid(subsystem.victors.get(name))) {
+                // Victors can follow Talons or another Victor.
                 return CtreMotorFactory.createPermanentSlaveVictor(
-                        subsystemConfig.victors.get(name), master
+                    subsystem.victors.get(name), master
                 );
             }
         }
         return CtreMotorFactory.createGhostTalon();
     }
 
+    private boolean isHardwareValid(Integer hardwareId) {
+        return hardwareId != null && hardwareId > -1;
+    }
+
     public Solenoid getSolenoid(String subsystem, String name) {
         Integer solenoidId = getSubsystem(subsystem).solenoids.get(name);
-        if (solenoidId != null) {
+        if (isHardwareValid(solenoidId)) {
             return new Solenoid(config.pcm, solenoidId);
         }
         return null;
     }
 
     public DoubleSolenoid getDoubleSolenoid(String subsystem, String name) {
-        YamlConfiguration.DoubleSolenoidConfig solenoidConfig = getSubsystem(subsystem).doublesolenoids.get(name);
-        if (solenoidConfig != null) {
+        YamlConfig.DoubleSolenoidConfig solenoidConfig = getSubsystem(subsystem).doublesolenoids.get(name);
+        if (
+            solenoidConfig != null
+            && isHardwareValid(solenoidConfig.forward)
+            && isHardwareValid(solenoidConfig.reverse)
+        ) {
             return new DoubleSolenoid(config.pcm, solenoidConfig.forward, solenoidConfig.reverse);
         }
         return null;
@@ -104,59 +91,12 @@ public class RobotFactory {
         return getSubsystem(subsystem).constants.get(name);
     }
 
-    public YamlConfiguration getConfig() {
+    public YamlConfig getConfig() {
         return config;
     }
 
-    public YamlConfiguration.SubsystemConfig getSubsystem(String subsystem) {
+    public YamlConfig.SubsystemConfig getSubsystem(String subsystem) {
         return config.subsystems.get(subsystem);
     }
 
-    // Since the Collections of configurations are injected by SnakeYaml,
-    // IDEs will report that the collections are never updated.
-    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
-    public static class YamlConfiguration {
-        Map<String, SubsystemConfig> subsystems;
-        Map<String, Double> constants = new HashMap<>();
-        int pcm;
-
-        public static class SubsystemConfig {
-            boolean implemented = false;
-            Map<String, Integer> talons = new HashMap<>();
-            Map<String, Integer> victors = new HashMap<>();
-            Map<String, Integer> solenoids = new HashMap<>();
-            Map<String, DoubleSolenoidConfig> doublesolenoids = new HashMap<>();
-            Map<String, Double> constants = new HashMap<>();
-            Integer canifier;
-
-            @Override
-            public String toString() {
-                return "Subsystem {\n" +
-                        "  implemented = " + implemented + ",\n" +
-                        "  talons = " + talons.toString() + ",\n" +
-                        "  victors = " + victors.toString() + ",\n" +
-                        "  solenoids = " + solenoids.toString() + ",\n" +
-                        "  doubleSolenoids = " + doublesolenoids.toString() + ",\n" +
-                        "  canifier = " + canifier + ",\n" +
-                        "  constants = " + constants.toString() + ",\n" +
-                        "}";
-            }
-        }
-
-        public static class DoubleSolenoidConfig {
-            int forward;
-            int reverse;
-
-            @Override
-            public String toString() {
-                return String.format("{ forward = %d, reverse = %d }", forward, reverse);
-            }
-        }
-
-        @Override
-        public String toString() {
-            return "YamlConfiguration {\n  subsystems = " + subsystems.toString() +
-                    "\n  pcm = " + pcm + "\n  constants = " + constants.toString( )+ "\n}";
-        }
-    }
 }

--- a/src/main/java/com/edinarobotics/utils/hardware/YamlConfig.java
+++ b/src/main/java/com/edinarobotics/utils/hardware/YamlConfig.java
@@ -1,0 +1,63 @@
+package com.edinarobotics.utils.hardware;
+
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.introspector.BeanAccess;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+// Since the Collections of configurations are injected by SnakeYaml,
+// IDEs will report that the collections are never updated.
+@SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+public class YamlConfig {
+    Map<String, SubsystemConfig> subsystems;
+    Map<String, Double> constants = new HashMap<>();
+    int pcm;
+
+    public static YamlConfig loadFrom(InputStream input) {
+        Yaml yaml = new Yaml(new Constructor(YamlConfig.class));
+        yaml.setBeanAccess(BeanAccess.FIELD);
+        return yaml.load(input);
+    }
+
+    public static class SubsystemConfig {
+        boolean implemented = false;
+        Map<String, Integer> talons = new HashMap<>();
+        Map<String, Integer> victors = new HashMap<>();
+        Map<String, Integer> solenoids = new HashMap<>();
+        Map<String, DoubleSolenoidConfig> doublesolenoids = new HashMap<>();
+        Map<String, Double> constants = new HashMap<>();
+        Integer canifier;
+
+        @Override
+        public String toString() {
+            return "SubsystemConfig {\n" +
+                    "  implemented = " + implemented + ",\n" +
+                    "  talons = " + talons.toString() + ",\n" +
+                    "  victors = " + victors.toString() + ",\n" +
+                    "  solenoids = " + solenoids.toString() + ",\n" +
+                    "  doublesolenoids = " + doublesolenoids.toString() + ",\n" +
+                    "  canifier = " + canifier + ",\n" +
+                    "  constants = " + constants.toString() + ",\n" +
+                    "}";
+        }
+    }
+
+    public static class DoubleSolenoidConfig {
+        int forward;
+        int reverse;
+
+        @Override
+        public String toString() {
+            return String.format("{ forward = %d, reverse = %d }", forward, reverse);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "YamlConfig {\n  subsystems = " + subsystems.toString() +
+                "\n  pcm = " + pcm + "\n  constants = " + constants.toString( )+ "\n}";
+    }
+}


### PR DESCRIPTION
The RobotFactory class was becoming really huge and cluttered over the course of the season, it was getting difficult to understand and navigate (we had triple-nested classes!) Anyways, I've had this branch up for a while, however, it wasn't appropriate or neccessary to merge midseason or especially before Champs.  If we don't merge it before state, we can do this offseason but we should do this before we merge this stuff into 1816-Project-Template. I've just rebased it against develop, so it should be a clean merge.