### PR TITLE
Create .editorconfig for consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
.editorconfig has already been adopted in CheezeCurd following @ddaymn's recommendation. It should save us from line-ending hell (see 3bef2028bcd1c526f2a6d34e7d520d9b9c10152f)